### PR TITLE
Add stripe checkout; pin dependencies in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,13 @@
 {
   "require": {
-    "craftcms/cms": "^3.6.4",
-    "vlucas/phpdotenv": "^3.4.0",
     "ext-curl": "*",
-    "ext-json": "*"
+    "ext-json": "*",
+    "craftcms/cms": "3.7.13",
+    "stripe/stripe-php": "7.100.0",
+    "vlucas/phpdotenv": "3.6.8"
   },
   "require-dev": {
-    "yiisoft/yii2-shell": "^2.0.3"
+    "yiisoft/yii2-shell": "2.0.4"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "22a1cc7f1cd024aeb0ba5bc3c0cf5ed8",
+    "content-hash": "2fb0658f5d3915f89969ecbbb84d8434",
     "packages": [
         {
             "name": "cebe/markdown",
@@ -2947,6 +2947,67 @@
                 "source": "https://github.com/Seldaek/phar-utils/tree/1.1.2"
             },
             "time": "2021-08-19T21:01:38+00:00"
+        },
+        {
+            "name": "stripe/stripe-php",
+            "version": "v7.100.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stripe/stripe-php.git",
+                "reference": "3dfc3dcd5d967a14d2852f34e544188af5f9b799"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/3dfc3dcd5d967a14d2852f34e544188af5f9b799",
+                "reference": "3dfc3dcd5d967a14d2852f34e544188af5f9b799",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "2.17.1",
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5.7",
+                "squizlabs/php_codesniffer": "^3.3",
+                "symfony/process": "~3.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stripe\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stripe and contributors",
+                    "homepage": "https://github.com/stripe/stripe-php/contributors"
+                }
+            ],
+            "description": "Stripe PHP Library",
+            "homepage": "https://stripe.com/",
+            "keywords": [
+                "api",
+                "payment processing",
+                "stripe"
+            ],
+            "support": {
+                "issues": "https://github.com/stripe/stripe-php/issues",
+                "source": "https://github.com/stripe/stripe-php/tree/v7.100.0"
+            },
+            "time": "2021-10-11T20:05:45+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -6095,10 +6156,13 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "ext-curl": "*",
+        "ext-json": "*"
+    },
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/modules/sitemodule/src/controllers/PaymentController.php
+++ b/modules/sitemodule/src/controllers/PaymentController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace modules\sitemodule\controllers;
+
+use Craft;
+use craft\web\Controller;
+
+class PaymentController extends Controller
+{
+    /**
+     * @var    bool|array Allows anonymous access to this controller's actions.
+     *         The actions must be in 'kebab-case'
+     * @access protected
+     */
+    protected $allowAnonymous = true;
+
+    public function actionCreateCheckoutSession()
+    {
+        \Stripe\Stripe::setApiKey('sk_test_HUPcOzbRokXXdG9IbNsh4wmB');
+        header('Content-Type: application/json');
+        $YOUR_DOMAIN = 'http://localhost:8888';
+
+        $amount = 1000; // TODO: make this dynamic
+
+        // TODO: See https://stackoverflow.com/a/66306163 for info on how to create a custom charge
+        $checkout_session = \Stripe\Checkout\Session::create([
+            'line_items' => [[
+                'price_data' => [
+                    'currency' => 'usd',
+                    'product_data' => [
+                        'name' => 'label_purchase',
+                    ],
+                    'unit_amount' => $amount,
+                ],
+                'quantity' => 1,
+            ]],
+            'payment_method_types' => [
+                'card',
+            ],
+            'mode' => 'payment',
+            'success_url' => $YOUR_DOMAIN . '/success.html',
+            'cancel_url' => $YOUR_DOMAIN . '/cancel.html',
+        ]);
+
+        $redirectUrl = $checkout_session->url;
+
+        header("HTTP/1.1 303 See Other");
+        header("Location: " . $redirectUrl);
+
+        return $this->redirect($redirectUrl);
+    }
+}

--- a/templates/cancel.jsp
+++ b/templates/cancel.jsp
@@ -1,0 +1,10 @@
+<html>
+<head>
+  <title>Checkout canceled</title>
+</head>
+<body>
+  <section>
+    <p>Forgot to add something to your cart? Shop around then come back to pay!</p>
+  </section>
+</body>
+</html>

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -2,11 +2,14 @@
 <html lang="en-US">
 <head>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?version=3.52.1&features=fetch"></script>
+    <script src="https://js.stripe.com/v3/"></script>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta charset="utf-8" />
     <title>Welcome Gavin Vaske</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="referrer" content="origin-when-cross-origin" />
+    <title>Buy cool new product</title>
     <style>
         html,
         body {
@@ -22,7 +25,7 @@
             background-color: hsl(212, 60%, 97%);
             color: hsl(209, 18%, 30%);
             display: flex;
-            text-align: center; 
+            text-align: center;
         }
         #modal {
             display: flex;
@@ -42,7 +45,7 @@
             justify-content: center;
             align-items: center;
         }
-    
+
         h1 {
             margin-top: 0;
 
@@ -94,6 +97,25 @@
                     Submit Form
                 </button>
             </form>
+
+            <section>
+                <div class="product">
+                    <img
+                            src="https://i.imgur.com/EHyR2nP.png"
+                            alt="The cover of Stubborn Attachments"
+                    />
+                    <div class="description">
+                        <h3>Label Purchase</h3>
+                        <h5>$10.00</h5>
+                    </div>
+                </div>
+                <form method="post">
+                    {{ csrfInput() }}
+                    <input type="hidden" name="action" value="site-module/payment/create-checkout-session">
+                    <button type="submit" id="checkout-button">Checkout</button>
+                </form>
+            </section>
+
         </div>
     </div>
 </div>
@@ -102,20 +124,12 @@
 
 <script>
     $('form.add-to-cart-form').on('submit', function(e) {
-        let log_message = 'add to cart clicked'
-        alert(log_message)
-        // console.log(log_message);
         e.preventDefault();
         let form_data = $('.add-to-cart-form').serializeArray();
-        alert(`BEFORE => ${JSON.stringify(form_data)}`);
         let csrfToken = window.csrfTokenValue
 
         form_data['CRAFT_CSRF_TOKEN'] = csrfToken	// Setting CSRF token in duplicate places redundently
-        form_data['TESTICLES'] = 'it workssss!'
         form_data['action'] = 'site-module/shipping/do-something'
-
-
-        alert(`AFTER => ${JSON.stringify(form_data)}`);
 
         $.ajax({
             type: 'post',
@@ -135,40 +149,4 @@
             }
         });
     });
-    // $(document).ready(function () {
-    //     $("#gavin-btn").click(function() {
-    //         sendAjaxRequest();
-    //     })
-    //
-    //     function sendAjaxRequest() {
-    //         let csrfToken = window.csrfTokenValue
-    //
-    //         alert('Before AJAX');
-    //
-    //         $.ajax({
-    //             type: 'post',
-    //             url: '',
-    //             headers: {
-    //                 "X-CSRF-Token" : csrfToken,
-    //             },
-    //             data:
-    //                 {
-    //                     'action' : 'site-module/shipping/do-something',
-    //                     'splitOneMeals' : 'bblah',
-    //                     'splitTwoMeals' : 'blaeha2',
-    //                 },
-    //             dataType: 'json',
-    //             success: function(response) {
-    //                 alert(`Ajax SUCCESS: => ${JSON.stringify(response)}`)
-    //             },
-    //             error: function(error) {
-    //                 alert(`Ajax Error: => ${JSON.stringify(error)}`)
-    //             }
-    //         });
-    //     }
-    // })
-
-    function gavinDoStuff() {
-        alert("You clicked a butt-on!");
-    }
 </script>

--- a/templates/success.html
+++ b/templates/success.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+    <title>Thanks for your order!</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<section>
+    <p>
+        We appreciate your business! If you have any questions, please email
+        <a href="mailto:orders@example.com">orders@example.com</a>.
+    </p>
+</section>
+</body>
+</html>
+</html>


### PR DESCRIPTION
## Description

This PR adds [Stripe Checkout](https://stripe.com/docs/checkout/integration-builder?server=php) which allows for credit card transactions which are handled by Stripe.

Stripe's own custom credit card page is utilized to remove the need for created a custom one. A screenshot of the Stripe checkout page is shown below:
![Screen Shot 2021-10-12 at 7 46 42 PM](https://user-images.githubusercontent.com/42784674/137048033-44525ddf-97fc-47a3-a63c-4361ccd829bb.png)

Upon successful payment, a user is redirected back to the website.

Payments are viewable via the [Stripe Dashboard](https://dashboard.stripe.com/test/payments)

**Note:** A test secret key is exposed in this PR and is not valid, but serves as an example until a proper `.env` is utilized which will contain the key safely


